### PR TITLE
First draft of new error checking functionality.

### DIFF
--- a/manifests/error.pp
+++ b/manifests/error.pp
@@ -1,0 +1,13 @@
+class tuned::error (
+  $errormsg = undef,
+){
+  case $errormsg {
+    # notify will log an error in the client output but continue on.
+    'WrongOs' : { notify{'WrongOS':message=>"Module ${module_name} is not supported on ${::operatingsystem}", } }
+    'WrongVariation' : { notify{'WrongVariation':message=>"Module ${module_name} does not support the ${::operatingsystem} variation.", } }
+    'WrongVersion' : { notify{'WrongVersion':message=>"Module ${module_name} does not support this version of ${::operatingsystem}.", } }
+    # fail will log an error and stop the client from continuing.
+    default : { fail("Module ${module_name} name has failed for unknown reasons.") }
+  }
+}
+

--- a/manifests/tuned.pp
+++ b/manifests/tuned.pp
@@ -1,0 +1,58 @@
+class tuned::tuned (
+  $profile = 'default',
+  $source  = undef,
+  $ensure  = present,
+) {
+  # Only if we are 'present'
+  if $ensure != 'absent' {
+  
+    # One package
+    package { 'tuned': ensure => $ensure }
+
+    # Two services
+    service { 'tuned' :
+      enable    => true,
+      ensure    => running,
+      hasstatus => true,
+      require   => Package['tuned'],
+    }
+    # Fedora doesn't have ktune thus it is an empty status  
+    if $::operatingsystem != 'Fedora' {
+      service { 'ktune' :
+        enable    => true,
+        ensure    => running,
+        hasstatus => true,
+        require   => Package['tuned'],
+      }
+    } else {
+      service { 'ktune' : }
+    }
+
+    # Enable the chosen profile
+    exec { "tuned-adm profile ${profile}":
+      unless  => "grep -q -e '^${profile}\$' /etc/tune-profiles/active-profile",
+      require => Package['tuned'],
+      before  => [ Service['tuned'], Service['ktune'] ],
+      path    => [ '/bin', '/usr/sbin' ],
+      # No need to notify services, tuned-adm restarts them alone
+    }
+
+    # Install the profile's file tree if source is given
+    if $source {
+      file { "/etc/tune-profiles/${profile}":
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        ensure  => directory,
+        recurse => true,
+        purge   => true,
+        source  => $source,
+        # For the parent directory
+        require => Package['tuned'],
+        before  => Exec["tuned-adm profile ${profile}"],
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Greetings,

Here is my latest update. The major changes are:
- Init.pp now has multiple checks for the OS family and version. I ran into multiple issues where the various OS's differed in their facter output. All of those problems have been accounted for.
- Tuned.pp was the old init.pp. Only major change is a fix to prevent Fedora from crashing on ktune.
- Error.pp supports multiple error messages such that adding new ones later on should be fairly easy to do.

I tested on Scientific Linux 6, CentOS 5 and 6, Fedora 18, SLES 11_, and Debian 6_.
*(gracefully notifies user and makes no changes). I don't have an Oracle box I can test on, but I know someone who was able to send me his facter output so that I could add a check in for it. Also, once you push up a new version to puppet forge and I can verify it runs without problems in my alpha-test environment, I can push it out to a slightly larger test farm of more distros ( off the top of my head, I should be able to test against RHEL 5 and 6, SL5, and a few other flavors of Fedora ).

If I can do something else, just let me know.

Thanks!
