### PR TITLE
Added support for newer version of tuned shipped with RHEL/CentOS 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,21 @@
+class tuned::params {
+
+  # Two services, except on Fedora and RHEL/CentOS 7
+  if ( $::operatingsystem == 'Fedora' ) or
+     ( $::operatingsystem =~ /^(RedHat|CentOS)$/ and versioncmp($::operatingsystemrelease, '7') >= 0 ) {
+
+    $tuned_services = [ 'tuned' ]
+
+    $profile_path   = "/etc/tuned"
+    $active_profile = "active_profile"
+
+  } else {
+
+    $tuned_services = [ 'tuned', 'ktune' ]
+
+    $profile_path   = "/etc/tune-profiles"
+    $active_profile = "active-profile"
+
+  }
+
+}


### PR DESCRIPTION
With RHEL/CentOS 7 releases, tuned was updated from version 0.2 to 2.3.
The main differences that make it not compatible with the puppet module are:
- ktune service was removed
- profile folder changed
- active-profile file changed

This patch addresses these issues so that these module can be used with
those operative systems maintaining backward compatibility. 
