### PR TITLE
separate options for package and service. exec replaced with file. default profile unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ class { '::tuned':
 }
 ```
 
-To completely stop, disable and remove tuned :
+To completely stop and disable tuned :
 
 ```puppet
-class { '::tuned': ensure => 'absent' }
+class { '::tuned':
+  service_ensure => stopped,
+  service_enable => false,
+}
 ```
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,15 +4,15 @@ class tuned::params {
   if ( $::operatingsystem == 'Fedora' ) or
     ( $::operatingsystem =~ /^(RedHat|CentOS|Scientific|OracleLinux|CloudLinux)$/ and versioncmp($::operatingsystemrelease, '7') >= 0 ) {
 
-    $default_profile = 'balanced'
     $tuned_services  = [ 'tuned' ]
+    $tuned_packages  = [ 'tuned' ]
     $profile_path    = '/etc/tuned'
     $active_profile  = 'active_profile'
 
   } else {
 
-    $default_profile = 'default'
     $tuned_services  = [ 'tuned', 'ktune' ]
+    $tuned_packages  = [ 'tuned' ]
     $profile_path    = '/etc/tune-profiles'
     $active_profile  = 'active-profile'
 

--- a/metadata.json
+++ b/metadata.json
@@ -28,5 +28,7 @@
     "version_requirement": ">=2.7.20 <4.0.0"
     }
   ],
-  "dependencies": []
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 0.2.0"}
+  ]
 }


### PR DESCRIPTION
Please consider merging my changes:

by default module does not changes profile - package/virtual specific is being used (balanced for hw and virt-guest for vm)
we have separate options for package, service and service_enable
exec replaced with file
stdlib dependency added because of using anchor

Thank you for your work.