### PR TITLE
Add settings parameter to manage creation of custom tuned profile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ class { '::tuned':
 }
 ```
 
+Install and enable tuned with a custom profile :
+
+```puppet
+class { '::tuned':
+  profile => 'my-super-tweaks',
+  settings => {
+    'main'   => { 'include' => 'virtual-guest' },
+    'sysctl' => { 'vm.dirty_ratio' => '30',
+                  'vm.swappiness'  => '30', },
+              },
+}
+```
+
 To completely stop, disable and remove tuned :
 
 ```puppet

--- a/templates/tuned.conf.erb
+++ b/templates/tuned.conf.erb
@@ -1,0 +1,12 @@
+#
+# File managed by Puppet in module tuned
+#
+<% if @settings -%>
+<% @settings.each_pair do |plugin,data| -%>
+
+[<%= plugin %>]
+<% data.each_pair do |key,value| -%>
+<%= key %>=<%= value %>
+<% end -%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Hi,
I add a new functionality to create custom tuned.conf profiles within the module.

Here is an example to use it:

``` puppet
class { '::tuned':
  profile => 'my-super-tweaks',
  settings => {
    'main'   => { 'include' => 'virtual-guest' },
    'sysctl' => { 'vm.dirty_ratio' => '30',
                  'vm.swappiness'  => '30', },
              },
}
```

The **settings** variable expect an hash with the different entries you need in your configuration.

I hope it will be helpful for others and you'll like this PR ;)
Thanks !
