### PR TITLE
make folder and custom profile creation explicit. Resolves #17

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,13 +53,18 @@ class tuned (
           ensure  => 'directory',
           owner   => 'root',
           group   => 'root',
-          # This magically becomes 755 for directories
-          mode    => '0644',
-          recurse => true,
+          mode    => '0755',
           purge   => true,
-          source  => $source,
           # For the parent directory
           require => Package['tuned'],
+        }
+        file { "${profile_path}/${profile}/tuned.conf":
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          recurse => true,
+          source  => $source,
+          require => File["${profile_path}/${profile}"],
           before  => Exec["tuned-adm profile ${profile}"],
           notify  => Service[$tuned_services],
         }


### PR DESCRIPTION
This makes sure the folder and the file within exist for custom profiles.

The previous comments suggested this had worked in the past (maybe older puppet version?) but making this explicit seems to me like the safest and most compatible approach.