### PR TITLE
init: Use os::family==RedHat to detect supported OS.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,9 +21,7 @@ class tuned (
   $active_profile = $::tuned::params::active_profile,
 ) inherits ::tuned::params {
 
-  # Support old facter versions without 'osfamily'
-  if ( $::operatingsystem == 'Fedora' ) or
-    ( $::operatingsystem =~ /^(RedHat|CentOS|Scientific|OracleLinux|CloudLinux)$/ and versioncmp($::operatingsystemrelease, '6') >= 0 ) {
+  if ( ( $facts['os']['family'] == 'RedHat' ) and versioncmp($::operatingsystemrelease, '6') >= 0 ) {
 
     # One package
     package { 'tuned': ensure => $ensure }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,7 @@
 class tuned::params {
 
   # Two services, except on Fedora and RHEL/CentOS 7
-  if ( $::operatingsystem == 'Fedora' ) or
-    ( $::operatingsystem =~ /^(RedHat|CentOS|Scientific|OracleLinux|CloudLinux)$/ and versioncmp($::operatingsystemrelease, '7') >= 0 ) {
+  if ( ( $facts['os']['family'] == 'RedHat' ) and versioncmp($::operatingsystemrelease, '7') >= 0 ) {
 
     $default_profile = 'balanced'
     $tuned_services  = [ 'tuned' ]


### PR DESCRIPTION
Any facter version not supporting structured facts is EoL.
This also automatically adds support for recent RHEL rebuilds
such as Rocky and AlmaLinux.